### PR TITLE
fix typo in README.md

### DIFF
--- a/README.md
+++ b/README.md
@@ -1,0 +1,3 @@
+# ODonut
+
+[![Open in Gitpod](https://gitpod.io/button/open-in-gitpod.svg)](https://gitpod.io/#https://github.com/JackAppDev/ODonut)

--- a/README.txt
+++ b/README.txt
@@ -1,1 +1,0 @@
-[![Open in Gitpod](https://gitpod.io/button/open-in-gitpod.svg)](https://gitpod.io/#https://github.com/<your-org>/<your-project>)


### PR DESCRIPTION
fix typo in README.md by update the link in Open in Gitpod and remove the previous place holder